### PR TITLE
chore: json schema validator generator

### DIFF
--- a/codegen/tsconfig.json
+++ b/codegen/tsconfig.json
@@ -17,6 +17,10 @@
         "./src/lib/*/index.ts"
       ]
     },
+    // https://github.com/microsoft/TypeScript/wiki/Performance#controlling-types-inclusion
+    "types": [
+      "node"
+    ],
     "resolveJsonModule": true,
     "outDir": "./dist",
     "isolatedModules": true,

--- a/frontend/src/codegen/generators/json-schema/generator.ts
+++ b/frontend/src/codegen/generators/json-schema/generator.ts
@@ -66,17 +66,9 @@ function toNestedModules(
   const moduleMap = Array.from(schemaMap.entries()).reduce<
     IGeneratedNestedModule["moduleMap"]
   >((moduleMap, [schemaPath, schema]) => {
-    const content = `export const schema = ${stringifyObject(schema)} as const`;
-    const moduleExports: IModuleInfo["exports"] = [
-      { name: "schema", type: "concrete" },
-    ];
-    const moduleInfos: IModuleInfo[] = [
-      {
-        name: "schema",
-        content,
-        exports: moduleExports,
-      },
-    ];
+    const schemaModule = createSchemaModule(schema);
+    const validationModule = createValidationModule(schema);
+    const moduleInfos: IModuleInfo[] = [schemaModule, validationModule];
 
     moduleMap.set(schemaPath, moduleInfos);
 
@@ -84,6 +76,36 @@ function toNestedModules(
   }, new Map());
 
   return moduleMap;
+}
+
+function createSchemaModule(schema: ISchema): IModuleInfo {
+  const content = `export const schema = ${stringifyObject(schema)} as const`;
+  const moduleExports: IModuleInfo["exports"] = [
+    { name: "schema", type: "concrete" },
+  ];
+
+  const moduleInfo: IModuleInfo = {
+    name: "schema",
+    content,
+    exports: moduleExports,
+  };
+
+  return moduleInfo;
+}
+
+function createValidationModule(schema: ISchema): IModuleInfo {
+  const moduleImports = `import {createValidator} from "#lib/json/schema"`;
+  const content = `export const validateSchema = () => {}`;
+  const moduleExports: IModuleInfo["exports"] = [
+    { name: "validateSchema", type: "concrete" },
+  ];
+  const moduleInfo: IModuleInfo = {
+    name: "validate",
+    content: [moduleImports, content].join("\n"),
+    exports: moduleExports,
+  };
+
+  return moduleInfo;
 }
 
 export default generateJSONSchemas;

--- a/frontend/src/codegen/output/json-schema/dates/constants/index.ts
+++ b/frontend/src/codegen/output/json-schema/dates/constants/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/dates/constants/validate.ts
+++ b/frontend/src/codegen/output/json-schema/dates/constants/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/dates/datetime/index.ts
+++ b/frontend/src/codegen/output/json-schema/dates/datetime/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/dates/datetime/validate.ts
+++ b/frontend/src/codegen/output/json-schema/dates/datetime/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/data-export/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/data-export/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/data-export/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/data-export/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/item/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/item/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/item/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/item/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/place/entity/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/place/entity/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/place/entity/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/place/entity/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/place/init/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/place/init/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/place/init/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/place/init/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/place/update/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/place/update/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/place/update/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/place/update/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/task/entity/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/entity/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/task/entity/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/entity/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/task/init/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/init/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/task/init/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/init/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/task/stats/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/stats/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/task/stats/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/stats/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/task/status/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/status/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/task/status/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/status/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/entities/task/update/index.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/update/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/entities/task/update/validate.ts
+++ b/frontend/src/codegen/output/json-schema/entities/task/update/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/numbers/non-negative-integer/index.ts
+++ b/frontend/src/codegen/output/json-schema/numbers/non-negative-integer/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/numbers/non-negative-integer/validate.ts
+++ b/frontend/src/codegen/output/json-schema/numbers/non-negative-integer/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/strings/description/index.ts
+++ b/frontend/src/codegen/output/json-schema/strings/description/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/strings/description/validate.ts
+++ b/frontend/src/codegen/output/json-schema/strings/description/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/strings/nanoid/index.ts
+++ b/frontend/src/codegen/output/json-schema/strings/nanoid/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/strings/nanoid/validate.ts
+++ b/frontend/src/codegen/output/json-schema/strings/nanoid/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};

--- a/frontend/src/codegen/output/json-schema/strings/title/index.ts
+++ b/frontend/src/codegen/output/json-schema/strings/title/index.ts
@@ -1,1 +1,2 @@
 export { schema } from "./schema";
+export { validateSchema } from "./validate";

--- a/frontend/src/codegen/output/json-schema/strings/title/validate.ts
+++ b/frontend/src/codegen/output/json-schema/strings/title/validate.ts
@@ -1,0 +1,6 @@
+/**
+ * This module was generated automatically.
+ * Do not edit it manually.
+ */
+import { createValidator } from "#lib/json/schema";
+export const validateSchema = () => {};


### PR DESCRIPTION
Only generates stubs because the default async nature
of `json-schema` functions makes it impossible to create
type-guards/assert functions in typescript for several
environments. Will probably use `ajv` for generating those.